### PR TITLE
Cria função `validate.py` com argumento `stop_on_failure`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ extract:
 	$(foreach resource_name, $(RESOURCE_NAMES),python main.py extract $(resource_name) &&) true
 
 validate: 
-	frictionless validate datapackage.yaml
+	python main.py validate datapackage.yaml
 
 transform: $(OUTPUT_FILES)
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import logging
 from scripts.extract import extract_resource
 from scripts.transform import transform_resource
 from scripts.build import build_package
+from scripts.validate import validate_package
 
 app = typer.Typer(pretty_exceptions_show_locals=False)
 
@@ -26,6 +27,7 @@ def resources(descriptor: str = 'datapackage.yaml'):
 app.command(name="extract")(extract_resource)
 app.command(name="transform")(transform_resource)
 app.command(name="build")(build_package)
+app.command(name="validate")(validate_package)
 
 if __name__ == "__main__":
     LOG_FORMAT = '%(asctime)s %(levelname)-5.5s [%(name)s] %(message)s'

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,35 @@
+import logging
+from frictionless import Package, Checklist
+import petl
+from frictionless import validate
+
+logger = logging.getLogger(__name__)
+
+def validate_package(descriptor, stop_on_failure: bool = False):
+    package = Package('datapackage.yaml')
+    
+    report = validate('datapacakge.yaml')
+
+    report_fields = ['title', 'rowNumber', 'fieldNumber', 'fieldName', 'description', 'message', 'note']
+    errors = [['resource'] + report_fields]
+
+    for resource in package.resources:
+        try:
+            report = resource.validate(limit_errors = 100) #checklist, 
+            data = report.flatten(report_fields)
+            table = [report_fields] + data
+            table = petl.addfield(table, 'resource', resource.name, 0)
+            errors = petl.cat(errors, table)
+        except Exception as err:
+            logger.error("%s: Unexpected error: %s", resource.name, err)         
+   
+    if errors.data():        
+        unique_errors = petl.cut(errors, ["resource", "fieldName", "title", "description", "note"]).distinct().records()
+        for row in unique_errors:
+            logger.warning(f"{row.resource}: Coluna '{row.fieldName}' | Erro '{row.title}' | Descrição '{row.description}' | Regra '{row.note}'")
+    
+        if stop_on_failure == True: 
+            raise Exception(errors)
+
+    return(errors)
+    

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -5,10 +5,10 @@ from frictionless import validate
 
 logger = logging.getLogger(__name__)
 
-def validate_package(descriptor, stop_on_failure: bool = False):
-    package = Package('datapackage.yaml')
+def validate_package(descriptor: str, stop_on_failure: bool = False):
+    package = Package(descriptor)
     
-    report = validate('datapacakge.yaml')
+    report = validate(descriptor)
 
     report_fields = ['title', 'rowNumber', 'fieldNumber', 'fieldName', 'description', 'message', 'note']
     errors = [['resource'] + report_fields]
@@ -31,5 +31,5 @@ def validate_package(descriptor, stop_on_failure: bool = False):
         if stop_on_failure == True: 
             raise Exception(errors)
 
-    return(errors)
-    
+    return errors
+   


### PR DESCRIPTION
@fjuniorr criei no repositório sem dados a função validate com argumento `stop_on_failure`, para que possamos nos próximos anos validar as bases do sigplan, sem que necessariamente paralise o código quando tiver inconformidades.

Uma dúvida que fiquei foi que chamando pelo `make validate`, não printa em tela a tabela `errors` da função. E chamando a função diretamente no vscode, printa somente algumas linhas. 

Gostaria de ver o print completo da tabela, de forma parecida com o que ocorre quando chamamos a função frictionless validate.

